### PR TITLE
beam centers as float

### DIFF
--- a/laserbeamsize/laserbeamsize.py
+++ b/laserbeamsize/laserbeamsize.py
@@ -366,10 +366,10 @@ def basic_beam_size(image):
     # find the centroid
     hh = np.arange(h, dtype=np.float)      # float avoids integer overflow
     vv = np.arange(v, dtype=np.float)      # ditto
-    xc = int(np.sum(np.dot(image, hh))/p)
-    yc = int(np.sum(np.dot(image.T, vv))/p)
+    xc = np.sum(np.dot(image, hh))/p
+    yc = np.sum(np.dot(image.T, vv))/p
 
-    # find the variances
+    # find the variances**2
     hs = hh-xc
     vs = vv-yc
     xx = np.sum(np.dot(image, hs**2))/p
@@ -378,7 +378,7 @@ def basic_beam_size(image):
 
     # Ensure that the case xx==yy is handled correctly
     if xx == yy:
-        disc = 2*xy
+        disc = np.abs(2*xy)
         phi = np.sign(xy) * np.pi/4
     else:
         diff = xx-yy


### PR DESCRIPTION
As my beams are not always perfeclty located at a pixel, I need the position as float and not int. Is there a reason for this restriction?

for disc of round beam ISO says abs(2*xy)