### PR TITLE
rotated_rect_mask speedup

### DIFF
--- a/test_beam_size.py
+++ b/test_beam_size.py
@@ -1,0 +1,28 @@
+import imageio
+import numpy as np
+import matplotlib.pyplot as plt
+import laserbeamsize as lbs
+
+beam = imageio.imread("./docs/k-200mm.png")
+x, y, dx, dy, phi = lbs.beam_size(beam)
+
+import unittest
+
+class TestBeamSize(unittest.TestCase):
+
+    def test_k_200mm(self):
+        beam = imageio.imread("./docs/k-200mm.png")
+        x, y, dx, dy, phi = lbs.beam_size(beam)
+        self.assertLess((x-580.9918940222431)**2, 0.0001)
+        self.assertLess((y-388.11071998805414)**2,0.0001)
+        self.assertLess((dx-187.54830372731638)**2,0.0001)
+        self.assertLess((dy-153.1901738600395)**2,0.0001)
+        self.assertLess((phi+0.4898844182586432)**2,0.0001)
+        
+
+        
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I want to use this package on data coming at 10Hz but found that the current version was too slow for this. After some profiling, I found that rotated_rect_mask is slow as it rotates the whole image instead of just drawing a rotated rectangle. I wrote an alternative implementation that does that. 

I also added a test to make sure that the result is the same as for the normal implementation and changed depreciated np.float to float.