### PR TITLE
Use built-in bool because np.bool is deprecated

### DIFF
--- a/laserbeamsize/laserbeamsize.py
+++ b/laserbeamsize/laserbeamsize.py
@@ -451,7 +451,7 @@ def perimeter_mask(image, corner_fraction=0.035):
     n = int(v * corner_fraction)
     m = int(h * corner_fraction)
 
-    the_mask = np.full_like(image, False, dtype=np.bool)
+    the_mask = np.full_like(image, False, dtype=bool)
     the_mask[:, :m] = True
     the_mask[:, -m:] = True
     the_mask[:n, :] = True


### PR DESCRIPTION
Simple edit, but the previously used np. bool is [deprecated since numpy 1.24](https://github.com/brightway-lca/brightway2/issues/64).