### PR TITLE
Fix cropping docstring typo

### DIFF
--- a/laserbeamsize/display.py
+++ b/laserbeamsize/display.py
@@ -170,7 +170,7 @@ def plot_image_and_fit(
     size is in pixels unless `pixel_size` is specified.  In that case the
     rectangle sizes are in whatever units `pixel_size` is .
 
-    All cropping is done after analysis and therefosre only affects
+    All cropping is done after analysis and therefore only affects
     what is displayed.  If the image needs to be cropped before analysis
     then that must be done before calling this function.
 
@@ -287,7 +287,7 @@ def plot_image_analysis(
     If `crop==True` then the displayed image is cropped to the ISO 11146 integration
     rectangle.
 
-    All cropping is done after analysis and therefosre only affects
+    All cropping is done after analysis and therefore only affects
     what is displayed.  If the image needs to be cropped before analysis
     then that must be done before calling this function.
 
@@ -471,7 +471,7 @@ def plot_image_montage(
     If `crop==True` then the displayed image is cropped to the ISO 11146 integration
     rectangle.
 
-    All cropping is done after analysis and therefosre only affects
+    All cropping is done after analysis and therefore only affects
     what is displayed.  If the image needs to be cropped before analysis
     then that must be done before calling this function.
 


### PR DESCRIPTION
## Summary
- fix 'therefosre' typo in docstrings in display utilities

## Testing
- `pytest -q` *(fails: No such kernel named python3)*

------
https://chatgpt.com/codex/tasks/task_e_684077e246f883269ea7671e9f82cf57