### PR TITLE
Fix centroid calculation in naive beam size

### DIFF
--- a/laserbeamsize/analysis.py
+++ b/laserbeamsize/analysis.py
@@ -253,8 +253,8 @@ def basic_beam_size_naive(image):
             p += image[i, j]
             xc += image[i, j] * j
             yc += image[i, j] * i
-    xc = int(xc / p)
-    yc = int(yc / p)
+    xc /= p
+    yc /= p
 
     # calculate variances
     xx = 0.0


### PR DESCRIPTION
## Summary
- fix `basic_beam_size_naive` so centroid is not truncated to an integer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68407666538883268338c9eea668a46b