### PR TITLE
Fix typo in beam_size docstring

### DIFF
--- a/laserbeamsize/analysis.py
+++ b/laserbeamsize/analysis.py
@@ -167,7 +167,7 @@ def beam_size(
 
     Args:
         image: 2D array of image of beam
-        mask_diameters: (optional) the size of the integratifon rectangle in diameters
+        mask_diameters: (optional) the size of the integration rectangle in diameters
         corner_fraction: (optional) the fractional size of the corners
         nT: (optional) the multiple of background noise to remove
         max_iter: (optional) maximum number of iterations.


### PR DESCRIPTION
## Summary
- fix a typo in `laserbeamsize.analysis.beam_size`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68407c8c38888326a064643686ae508f