### PR TITLE
Support fixed phi in beam_size

### DIFF
--- a/tests/test_fixed_phi.py
+++ b/tests/test_fixed_phi.py
@@ -1,0 +1,24 @@
+import numpy as np
+import laserbeamsize as lbs
+
+
+def create_image(phi=np.pi / 6):
+    return lbs.image_tools.create_test_image(400, 400, 200, 200, 80, 40, phi)
+
+
+def test_basic_beam_size_phi_returned():
+    image = create_image()
+    result = lbs.basic_beam_size(image, phi=0)
+    assert np.isclose(result[4], 0)
+
+
+def test_basic_beam_size_naive_phi_returned():
+    image = create_image().astype(float)
+    result = lbs.analysis.basic_beam_size_naive(image, phi=np.pi / 4)
+    assert np.isclose(result[4], np.pi / 4)
+
+
+def test_beam_size_phi_returned():
+    image = create_image()
+    result = lbs.beam_size(image, phi=-np.pi / 3)
+    assert np.isclose(result[4], -np.pi / 3)

--- a/tests/test_fixed_phi.py
+++ b/tests/test_fixed_phi.py
@@ -8,13 +8,17 @@ def create_image(phi=np.pi / 6):
 
 def test_basic_beam_size_phi_returned():
     image = create_image()
+    expected = lbs.basic_beam_size(image)
     result = lbs.basic_beam_size(image, phi=0)
+    assert np.allclose(result[:4], expected[:4], rtol=1e-2)
     assert np.isclose(result[4], 0)
 
 
 def test_basic_beam_size_naive_phi_returned():
     image = create_image().astype(float)
+    expected = lbs.analysis.basic_beam_size_naive(image)
     result = lbs.analysis.basic_beam_size_naive(image, phi=np.pi / 4)
+    assert np.allclose(result[:4], expected[:4], rtol=1e-2)
     assert np.isclose(result[4], np.pi / 4)
 
 


### PR DESCRIPTION
## Summary
- allow `basic_beam_size`/`basic_beam_size_naive` to accept an optional `phi`
- compute diameters using the given angle when provided
- pass `phi` through `beam_size` so orientation can be fixed
- add tests confirming the phi argument is returned when specified

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b51f897c8326baba3d8d5ce78af1