### PR TITLE
Add beam size tutorial notebook

### DIFF
--- a/docs/16-Beam-Size-Tutorial.ipynb
+++ b/docs/16-Beam-Size-Tutorial.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8eb13318",
+   "metadata": {},
+   "source": [
+    "# Laserbeamsize Tutorial: Measuring Beam Size\n",
+    "\n",
+    "This notebook demonstrates how to use `laserbeamsize` to measure the size of a laser beam from an image. You will learn how to load an image, run the `beam_size` function, and interpret the results.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81fb7379",
+   "metadata": {},
+   "source": [
+    "## Installation and Setup\n",
+    "\n",
+    "Install the package using pip:\n",
+    "```bash\n",
+    "pip install laserbeamsize\n",
+    "```\n",
+    "The main dependency for this tutorial is `laserbeamsize`. We also use `imageio.v3` to load images.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17be4497",
+   "metadata": {},
+   "source": [
+    "## Loading a Beam Image\n",
+    "\n",
+    "Load your beam image file using `imageio.v3.imread`. Grayscale PGM or PNG images work well. The image should contain only the beam spot with minimal background features.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3657b9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import imageio.v3 as iio\n",
+    "import laserbeamsize as lbs\n",
+    "\n",
+    "image = iio.imread('path/to/your/image.pgm')\n",
+    "x, y, dx, dy, phi = lbs.beam_size(image)\n",
+    "print(f\"center=({x:.1f}, {y:.1f}), size=({dx:.2f}, {dy:.2f}), angle={phi:.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87ed7317",
+   "metadata": {},
+   "source": [
+    "## Calculating the Beam Ellipse\n",
+    "\n",
+    "The `beam_size` function fits an ellipse to the beam spot using the ISO 11146 standard. It returns the center position `(x, y)`, the beam diameters along the major and minor axes `(dx, dy)`, and the rotation angle `phi`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bb9c277",
+   "metadata": {},
+   "source": [
+    "## Interpreting `beam_size` Output\n",
+    "\n",
+    "- `x`, `y`: pixel coordinates of the ellipse center.\n",
+    "- `dx`, `dy`: full widths at $1/e^2$ along the major and minor axes.\n",
+    "- `phi`: rotation angle (radians) of the ellipse with respect to the x-axis.\n",
+    "Use these values to estimate beam radius or to align your setup.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b653fff",
+   "metadata": {},
+   "source": [
+    "## What Makes a Good Beam Image?\n",
+    "\n",
+    "* Use an exposure time that avoids saturation but captures enough signal.\n",
+    "* Center the beam in the field of view.\n",
+    "* Avoid reflections or additional light sources.\n",
+    "* Use a resolution that clearly shows the beam shape without oversampling.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handling Background Noise\n",
+    "\n",
+    "Background light and camera noise can bias the beam size calculation.\n",
+    "- Subtract a dark frame if possible.\n",
+    "- Crop the image so that the beam occupies most of the frame.\n",
+    "- For persistent patterns, consider capturing a reference background image and subtracting it from the beam image before analysis.\n",
+    "\n",
+    "The `beam_size` function works best when the image background is close to zero and noise is minimized."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ae66643",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "With a well-exposed beam image and minimal background, `laserbeamsize` can quickly estimate your beam diameter. Use the output parameters to monitor beam quality or align optics.\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new Jupyter notebook `16-Beam-Size-Tutorial.ipynb` outlining a basic tutorial for laserbeamsize
- expand tutorial with installation steps, code example, interpretation guidance, good image tips, and background noise handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472fa035e08326a05cfce03d1281c6